### PR TITLE
fix: typo `bracnh` -> `branch`

### DIFF
--- a/courses/git/README.md
+++ b/courses/git/README.md
@@ -26,7 +26,7 @@
 - `git reset --hard <commit-hash>`: Move the branch Head to a certain commit
 - `git mv <source> <destination>`: Move a file/directory from one place to another while tracking
 - `git remote add origin <repository-name>`: Add a remote tracking branch
-- `git push --set-upstream origin <branch-name> <repository-name>`: Set a remote for a bracnh
+- `git push --set-upstream origin <branch-name> <repository-name>`: Set a remote for a branch
 - `git push -u origin <branch-name> <repository-name>`: Set a remote for a brach (Same to the above one)
 - `git push`: Push local commits
 - `git fetch`: Fetch commits from origin


### PR DESCRIPTION
the `brach` typo directly underneath my change was left untouched as #13 already fixes it.