### PR TITLE
Fix: Remove duplicate line in Docker README.md

### DIFF
--- a/courses/docker+docker-compose/README.md
+++ b/courses/docker+docker-compose/README.md
@@ -26,7 +26,6 @@
 - `docker run -it --entrypoint <entrypoint_command> <image>`: Run a container and overwrite the default entrypoint
 - `docker inspect <container_name>`: Get details about the container
 - `docker exec -it <image_name> <command>`: Execute a command in a running container with interactive mode
-- `docker login`: Login into a Docker Repository
 - `docker -v <volume_name>:<path_in_container> <image>`: Bind path in the container to a Docker volume
 - `docker -v <path_in_host>:<path_in_container> <image>`: Bind path in the container to another path in the host
 - `docker volume ls`: List all volumes


### PR DESCRIPTION
Removes duplicate line in Docker v1 Course [`Readme.md`](https://github.com/abduvik/just-enough-series/blob/b034753dd0cba6e933c6d255f8a6068975bd6444/courses/docker+docker-compose/README.md). There are two ([`1`](https://github.com/abduvik/just-enough-series/blob/b034753dd0cba6e933c6d255f8a6068975bd6444/courses/docker%2Bdocker-compose/README.md?plain=1#L29),[`2`](https://github.com/abduvik/just-enough-series/blob/b034753dd0cba6e933c6d255f8a6068975bd6444/courses/docker%2Bdocker-compose/README.md?plain=1#L42)) instances of `docker login`, removed one that appeared towards the top of the list. With this change only a single instance of `docker login` remains.